### PR TITLE
Implement expiry date of qualifications

### DIFF
--- a/backend/src/Qualifications/qualification.model.ts
+++ b/backend/src/Qualifications/qualification.model.ts
@@ -10,6 +10,7 @@ const QualificationSchema: Schema = new Schema(
         fileId: { type: String, required: true },
         user: { type: mongoose.Types.ObjectId, ref: "User" },
         qualificationType: { type: mongoose.Types.ObjectId, ref: "QualificationType" },
+        expiryDate: {type: String, required: true },
         approved: { type: Boolean, default: false },
     },
     {

--- a/backend/src/Qualifications/qualifications.controller.ts
+++ b/backend/src/Qualifications/qualifications.controller.ts
@@ -47,6 +47,7 @@ export const createQualification = async (req: Request, res: Response) => {
             filePath: uploadResponse.secure_url,
             fileId: uploadResponse.public_id,
             qualificationType: newQualification?.qualificationType,
+            expiryDate: newQualification.expiryDate,
             approved: !qualificationtype.requiresApproval, // assume that the qualification is approved if it required no admin approval
             user: user._id,
         });
@@ -114,6 +115,7 @@ export const updateQualificationById = async (req: Request, res: Response) => {
 
         qualification.title = qualificationFields.title;
         qualification.description = qualificationFields.description;
+        qualification.expiryDate = qualificationFields.expiryDate;
 
         await qualification.save();
 

--- a/backend/src/Qualifications/qualifications.interface.ts
+++ b/backend/src/Qualifications/qualifications.interface.ts
@@ -20,6 +20,7 @@ export interface IBasicQualification {
     fileId: string;
     user: Types.ObjectId;
     qualificationType: Types.ObjectId;
+    expiryDate: string;
     approved: boolean;
 }
 
@@ -31,5 +32,6 @@ export interface QualificationSummary {
     description: string;
     filePath: string;
     qualificationType: IQualificationType;
+    expiryDate: string;
     approved: boolean;
 }

--- a/frontend/src/api/qualificationAPI.ts
+++ b/frontend/src/api/qualificationAPI.ts
@@ -16,6 +16,7 @@ export interface Qualification {
     fileId: string;
     user: string;
     qualificationType: IQualificationType;
+    expiryDate: string;
     approved: boolean;
 }
 
@@ -27,6 +28,7 @@ export interface NewQualification {
     fileId: string;
     user: string;
     qualificationType: string;
+    expiryDate: string;
 }
 
 const PATH = `${window.location.origin}/api/qualifications`;
@@ -48,6 +50,7 @@ export async function createQualification(
     description: string,
     filePath: string,
     selectedQualType: string,
+    expiryDate: string,
     userId?: string
 ): Promise<ResponseWithStatus> {
     const payload: NewQualification = {
@@ -58,6 +61,7 @@ export async function createQualification(
         description,
         filePath,
         qualificationType: selectedQualType,
+        expiryDate,
     };
     return await postAndGetBasicResponse(`${PATH}/create`, payload as unknown as Record<string, unknown>);
 }
@@ -67,6 +71,7 @@ interface QualificationPatch {
     title: string;
     description: string;
     selectedQualType: string;
+    expiryDate: string;
     user?: string;
 }
 export async function updateQualification({
@@ -74,6 +79,7 @@ export async function updateQualification({
     title,
     description,
     user,
+    expiryDate,
     selectedQualType,
 }: QualificationPatch): Promise<ResponseWithStatus> {
     const payload: NewQualification = {
@@ -83,6 +89,7 @@ export async function updateQualification({
         title,
         description,
         filePath: "",
+        expiryDate,
         qualificationType: selectedQualType,
     };
 

--- a/frontend/src/profile/qualifications/createQualificationModal.tsx
+++ b/frontend/src/profile/qualifications/createQualificationModal.tsx
@@ -30,6 +30,7 @@ export const CreateOrEditQualificationModal = (props: CreateOrEditQualificationP
     const [description, setDescription] = useState("");
     const [file, setFile] = useState<File | null>(null);
     const [selectedQualType, setSelectedQualType] = useState<string>("");
+    const [expiryDate, setExpiryDate] = useState("");
 
     const [uploading, setUploading] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
@@ -45,6 +46,10 @@ export const CreateOrEditQualificationModal = (props: CreateOrEditQualificationP
     const handleQualTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         console.log(e.target.value);
         setSelectedQualType(e.target.value);
+    };
+
+    const onChangeExpiryDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setExpiryDate(e.target.value);
     };
 
     const onChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -64,6 +69,10 @@ export const CreateOrEditQualificationModal = (props: CreateOrEditQualificationP
     const onSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!selectedQualType) return setErrorMessage("You must select a qualification type.");
+
+        if (Date.parse(expiryDate) < Date.now()) {
+            return setErrorMessage("You cannot submit an expired qualification.");
+        }
 
         if (!props.isNew) {
             void uploadImage("");
@@ -93,12 +102,20 @@ export const CreateOrEditQualificationModal = (props: CreateOrEditQualificationP
         try {
             const { isNew, qualification } = props;
             const response = await (isNew
-                ? createQualification(title, description, base64EncodedImage, selectedQualType, qualification.user)
+                ? createQualification(
+                      title,
+                      description,
+                      base64EncodedImage,
+                      selectedQualType,
+                      expiryDate,
+                      qualification.user
+                  )
                 : updateQualification({
                       _id: qualification._id,
                       title,
                       description,
                       selectedQualType,
+                      expiryDate,
                       user: qualification.user,
                   }));
             if (!response.success) {
@@ -117,7 +134,7 @@ export const CreateOrEditQualificationModal = (props: CreateOrEditQualificationP
 
     // const { title, description, fileName, file, errorMessage, uploading } = this.state;
     const { isNew, onClose } = props || {};
-    const disabled = (isNew && !(title && fileName && file)) || !(title && description) || uploading;
+    const disabled = (isNew && !(title && fileName && file && expiryDate)) || !(title && description) || uploading;
     return (
         <Modal show={true} onHide={onClose} backdrop="static">
             <Modal.Header closeButton={!uploading}>
@@ -151,6 +168,16 @@ export const CreateOrEditQualificationModal = (props: CreateOrEditQualificationP
                                 );
                             })}
                         </Form.Select>
+                    </Form.Group>
+                    <Form.Group controlId="qExpiryDate" className="mb-3">
+                        <Form.Label>Expiry Date</Form.Label>
+                        <Form.Control
+                            type="date"
+                            name="qExpiryDate"
+                            value={expiryDate}
+                            onChange={onChangeExpiryDate}
+                            required
+                        />
                     </Form.Group>
                     {isNew && (
                         <Form.Group controlId="qFile" className="mb-3">

--- a/frontend/src/profile/qualifications/qualificationManagement.tsx
+++ b/frontend/src/profile/qualifications/qualificationManagement.tsx
@@ -121,6 +121,7 @@ export const QualificationsSection = ({ userId, isAdmin }: QualificationSectionP
                     <tr>
                         <th>Name</th>
                         <th>Qualification Type</th>
+                        <th>Expiry Date</th>
                         <th>Approval Status</th>
                         <th>Delete</th>
                         <th>Evidence</th>
@@ -134,6 +135,16 @@ export const QualificationsSection = ({ userId, isAdmin }: QualificationSectionP
                                 <tr key={qual._id}>
                                     <td>{qual.title}</td>
                                     <td>{qual.qualificationType.name}</td>
+                                    <td>
+                                        {Date.parse(qual.expiryDate) < Date.now() ? (
+                                            <div title="This qualification is expired." style={{ color: "red" }}>
+                                                {qual.expiryDate} {"   "}
+                                                <i className="bi bi-exclamation-square" />
+                                            </div>
+                                        ) : (
+                                            <div>{qual.expiryDate}</div>
+                                        )}
+                                    </td>
                                     <td>{qual.approved ? "Yes" : "No"}</td>
                                     <td>
                                         <Button
@@ -180,6 +191,7 @@ export const QualificationsSection = ({ userId, isAdmin }: QualificationSectionP
                         title: "",
                         user: isAdmin && userId ? userId : "",
                         qualificationType: "",
+                        expiryDate: "",
                         fileId: "",
                     }}
                     onClose={() => {
@@ -210,6 +222,7 @@ export const QualificationsSection = ({ userId, isAdmin }: QualificationSectionP
                             <>
                                 <p>Name: {selectedQualification.title}</p>
                                 <p>Description: {selectedQualification?.description}</p>
+                                <p>Expiry Date: {selectedQualification.expiryDate}</p>
                                 <p>Approval Status: {selectedQualification.approved ? "Yes" : "No"}</p>
                                 <img src={selectedQualification.filePath}></img>
                             </>


### PR DESCRIPTION
Added qualification expiry date - required when uploading qualification and displays in the list of qualifications and the Evidence modal.

Currently this checks for expiry date when uploading a certification and displays a warning in a user's list of qualifications when a qualification is expired. Doesn't yet do anything fancy like alerting an admin when a qualification expires.